### PR TITLE
Added look for newer version and display in console and gui if available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simonsays_drgreengiant"
-version = "2.0.0"
+version = "2.0.1"
 authors = [{ name = "Simon Howroyd", email = "howroydlsu@gmail.com" }]
 description = "A Twitch Plays style programme to allow users in Twitch chats to control the broadcasters mouse and keyboard"
 keywords = ["twitch", "chat", "twitchplays", "troll"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Pillow
 pynput
+requests
+semantic-version
 tomlkit
 twitchirc_drgreengiant
-semantic-version

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Pillow
 pynput
 tomlkit
 twitchirc_drgreengiant
+semantic-version

--- a/src/simonsays_drgreengiant/gui.py
+++ b/src/simonsays_drgreengiant/gui.py
@@ -8,6 +8,8 @@ import tkinter as tk
 from collections.abc import Iterable
 from typing import Any, Callable, NoReturn, Optional
 
+import semantic_version
+
 from . import config, environment, hidactions
 
 KEY_IGNORED_STR = 'ignored'
@@ -171,7 +173,7 @@ def make_window(cfg: config.Config, width_px: int, height_px: int) -> tk.Tk:
     return window
 
 
-def make_canvas(cfg: config.Config, image_path: str, *, window: tk.Tk | None = None) -> tk.Canvas:
+def make_canvas(cfg: config.Config, image_path: str, updateavailable: semantic_version = None, *, window: tk.Tk | None = None) -> tk.Canvas:
     """Make the canvas with a background image"""
     # img = tk.PhotoImage(file=image_path)
     from PIL import Image
@@ -187,7 +189,13 @@ def make_canvas(cfg: config.Config, image_path: str, *, window: tk.Tk | None = N
     canvas.image = img  # Keep a reference to the image to prevent garbage collection
     channels = "\n".join(cfg.channel)
     canvas.create_text((5, 5), text=f"Connected to channels:\n{channels}", anchor=tk.N + tk.W)
-    canvas.create_text((img.width() - 5, 5), text=f"Version: {cfg.version}", anchor=tk.N + tk.E)
+
+    versiontext = f"Version: {cfg.version}"
+    if updateavailable:
+        versiontext += "\nNew version available!"
+        versiontext += f"\nLatest version: {updateavailable}"
+
+    canvas.create_text((img.width() - 5, 5), text=versiontext, anchor=tk.N + tk.E)
 
     window.update()
 
@@ -490,9 +498,9 @@ def enabled_cb(cfg: config.Config, enabled_button: tk.Button, state_var: tk.Bool
         print("Enabled")
 
 
-def make_gui(cfg: config.Config) -> tuple[tk.Tk, mp.Event, Callable]:
+def make_gui(cfg: config.Config, updateavailable: semantic_version.Version = None) -> tuple[tk.Tk, mp.Event, Callable]:
     """Make the GUI"""
-    canvas = make_canvas(cfg, environment.resource_path("assets", "Green_tato_640.png"))
+    canvas = make_canvas(cfg, environment.resource_path("assets", "Green_tato_640.png"), updateavailable)
     window = canvas.winfo_toplevel()
 
     triggerredraw = mp.Event()


### PR DESCRIPTION
# Description

When not in offline mode, we use the GitHub API to get the latest release tag name.  We compare this against the version in the code at runtime to see if we're on an old version.  If so, this will show in the console and on the GUI.

New dependency on `semantic-version` which can be `pip` installed.

Fixes #53 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ Y] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

